### PR TITLE
fix: bookmark folder를 만들 때의 url을 수정한다.

### DIFF
--- a/src/pages/Popup/PopupContainer.js
+++ b/src/pages/Popup/PopupContainer.js
@@ -14,7 +14,7 @@ const PopupContainer = () => {
 
   const postServer = async (state) => {
     try {
-      await axios.post(HOST + '/bookmark', state, {
+      await axios.post(HOST + '/bookmark-folder', state, {
         headers: { Authorization: `Bearer ${token}` },
       });
       alert('Bookmarks are saved successfully!');


### PR DESCRIPTION
### Summary
- bookmark folder를 만들 때의 url을 수정한다.
- 서버에서 api의 url이 bookmark => bookmark-folder로 수정됨

### References

### Checklist
- [x] 로컬에서 잘 작동하는지 확인했는가
- [x] code style이 lint rule에 맞는가
- [ ] 테스트를 작성했는가
- [x] Base branch 를 알맞게 설정하였는가
- [x] Reviewers, Assignees, Labels 등을 적절히 지정했는가
