### PR TITLE
style: home page에서 반응형 style을 제거한다.

### DIFF
--- a/src/Components/FolderRow.js
+++ b/src/Components/FolderRow.js
@@ -27,11 +27,14 @@ export default function FolderRow({ bookmarkFolderList, isLoggedIn, type }) {
           {type === 'card'
             ? bookmarkFolderList.map((folderData, index) => {
                 return (
-                  <Folder
+                  <FolderWrapper
                     key={index}
-                    {...{ folderData }}
-                    folderCoverImageSrc={mapIndexToImageSrc[index % 4]}
-                  />
+                  >
+                    <Folder
+                      {...{ folderData }}
+                      folderCoverImageSrc={mapIndexToImageSrc[index % 4]}
+                    />
+                  </FolderWrapper>
                 );
               })
             : bookmarkFolderList.map((folderData, index) => {
@@ -56,9 +59,16 @@ export default function FolderRow({ bookmarkFolderList, isLoggedIn, type }) {
 const Container = styled.div`
   width: 100%;
   display: flex;
-  justify-content: space-between;
   flex-wrap: wrap;
   margin: 20px auto 0 auto;
+`;
+
+const FolderWrapper = styled.div`
+  margin-right: 19px;
+  
+  &:nth-child(4) {
+    margin-right: 0;
+  }
 `;
 
 const NotLoggedInWrapper = styled.div``;

--- a/src/Routes/Home/HomeContainer.js
+++ b/src/Routes/Home/HomeContainer.js
@@ -20,8 +20,6 @@ const HomeScreenContainer = () => {
     userReducer.user.isLoggedIn,
   ]);
 
-  console.log('asdf');
-
   return (
     <HomePresenter
       bookmarkFolderList={bookmarkReducer.bookmarkFolderList}

--- a/src/Routes/Home/HomePresenter.js
+++ b/src/Routes/Home/HomePresenter.js
@@ -26,7 +26,7 @@ const HomeScreenPresenter = ({
 };
 
 const Container = styled.div`
-  max-width: 1185px;
+  width: 1185px;
   margin: 0 auto;
 `;
 


### PR DESCRIPTION
### Summary
- home page에서 반응형 스타일을 제거한다.
- 한 줄에 4개씩 들어가지 않는 경우 폴더 사이의 마진이 부적절하게 생기기 때문

### References

### Checklist
- [ ] 로컬에서 잘 작동하는지 확인했는가
- [ ] code style이 lint rule에 맞는가
- [ ] 테스트를 작성했는가
- [ ] Base branch 를 알맞게 설정하였는가
- [ ] Reviewers, Assignees, Labels 등을 적절히 지정했는가
